### PR TITLE
FR-15672 - Support multi frameworks testing

### DIFF
--- a/.github/workflows/sdk-test-suite.yaml
+++ b/.github/workflows/sdk-test-suite.yaml
@@ -12,10 +12,18 @@ on:
         required: false
         description: Set the e2e-api tests branch tag
         default: master
-      react_version:
+      react_version: # deprecated
         type: string
         required: false
         description: Set the react version
+      client_framework:
+        type: string
+        required: false
+        description: Set the framework name        
+      client_framework_version:
+        type: string
+        required: false
+        description: Set the sdk version
       dispatch_id:
         type: string
         required: false
@@ -90,7 +98,7 @@ jobs:
           description: 'Start tests environment ${{ steps.variables.outputs.apiUrl }}'
 
   run-e2e-test:
-    name: "Run E2E tests react@${{ inputs.react_version }}"
+    name: "Run E2E tests ${{ inputs.client_framework || 'react' }}@${{ inputs.client_framework_version || inputs.react_version }}"
     runs-on: ubuntu-latest
     needs: [ prepare-params ]
     steps:
@@ -122,7 +130,9 @@ jobs:
           AZURE_APP_CLIENT_ID: ${{ secrets.AZURE_APP_CLIENT_ID }}
           AZURE_APP_SECRET: ${{ secrets.AZURE_APP_SECRET }}
           dispatch_id: ${{ inputs.dispatch_id }}
-          react_version: ${{ inputs.react_version }}
+          react_version: ${{ inputs.react_version }} # deprecated
+          client_framework: ${{ inputs.client_framework }}
+          client_framework_version: ${{ inputs.client_framework_version }}
           bot_token: ${{ env.BOT_TOKEN }}
           environment: "staging"
           frontegg_client_id: ${{ secrets.FRONTEGG_STG_CLIENT_ID }}


### PR DESCRIPTION
Support multi-framework testing by adding new inputs. `react_version` is deprecated and may be deleted later.