### PR TITLE
add shards

### DIFF
--- a/.github/workflows/full-test-suite.yaml
+++ b/.github/workflows/full-test-suite.yaml
@@ -25,11 +25,6 @@ on:
         type: string
         required: false
         description: Dispatch id to update status (repo/sha)
-      shards:
-        type: number
-        required: false
-        description: Number of shards to split tests into for parallel execution
-        default: 1
     secrets:
       GH_REPOSITORY_ADMIN_TOKEN:
         description: 'Github repository admin token'

--- a/.github/workflows/full-test-suite.yaml
+++ b/.github/workflows/full-test-suite.yaml
@@ -124,7 +124,7 @@ jobs:
           description: 'Start tests environment ${{ steps.variables.outputs.apiUrl }}'
 
   run-e2e-test:
-    name: Run E2E Tests on Venv (Shard ${{ matrix.shard }}/${{ inputs.shards }})
+    name: Run E2E Tests on Venv
     needs: [ prepare-params ]
     if: |
       always() &&
@@ -144,7 +144,7 @@ jobs:
     secrets: inherit
 
   run-api-test:
-    name: Run API Tests on Venv (Shard ${{ matrix.shard }}/${{ inputs.shards }})
+    name: Run API Tests on Venv
     needs: [ prepare-params ]
     if: |
       always() &&

--- a/.github/workflows/full-test-suite.yaml
+++ b/.github/workflows/full-test-suite.yaml
@@ -132,13 +132,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: ${{ fromJSON(format('[{0}]', join(range(1, inputs.shards + 1), ','))) }}
+        shard: [1, 2, 3]
     uses: frontegg/e2e-system-tests/.github/workflows/execute-test-command.yaml@master
     with:
       server_url: ${{ needs.prepare-params.outputs.apiUrl }}
       portal_url: ${{ needs.prepare-params.outputs.portalUrl }}
       command: |
-        FRAMEWORK="react" yarn run test:e2e:sanity --shard=${{ matrix.shard }}/${{ inputs.shards }}
+        FRAMEWORK="react" yarn run test:e2e:sanity --shard=${{ matrix.shard }}/3
       workflowName: "E2E Tests on Venv"
       runs_on: ubuntu-latest-4-cores
     secrets: inherit
@@ -152,12 +152,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: ${{ fromJSON(format('[{0}]', join(range(1, inputs.shards + 1), ','))) }}
+        shard: [1, 2, 3]
     uses: frontegg/e2e-system-tests/.github/workflows/execute-test-command.yaml@master
     with:
       server_url: ${{ needs.prepare-params.outputs.apiUrl }}
       portal_url: ${{ needs.prepare-params.outputs.portalUrl }}
-      command: "yarn test:api --shard=${{ matrix.shard }}/${{ inputs.shards }}"
+      command: "yarn test:api --shard=${{ matrix.shard }}/3"
       workflowName: "API Tests on Venv"
     secrets: inherit
 

--- a/.github/workflows/full-test-suite.yaml
+++ b/.github/workflows/full-test-suite.yaml
@@ -25,6 +25,11 @@ on:
         type: string
         required: false
         description: Dispatch id to update status (repo/sha)
+      shards:
+        type: integer
+        required: false
+        description: Number of shards to split tests into for parallel execution
+        default: 1
     secrets:
       GH_REPOSITORY_ADMIN_TOKEN:
         description: 'Github repository admin token'
@@ -119,32 +124,40 @@ jobs:
           description: 'Start tests environment ${{ steps.variables.outputs.apiUrl }}'
 
   run-e2e-test:
-    name: Run E2E Tests on Venv
+    name: Run E2E Tests on Venv (Shard ${{ matrix.shard }}/${{ inputs.shards }})
     needs: [ prepare-params ]
     if: |
       always() &&
       !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ${{ range(1, inputs.shards + 1) }}
     uses: frontegg/e2e-system-tests/.github/workflows/execute-test-command.yaml@master
     with:
       server_url: ${{ needs.prepare-params.outputs.apiUrl }}
       portal_url: ${{ needs.prepare-params.outputs.portalUrl }}
       command: |
-        FRAMEWORK="react"  yarn run test:e2e:sanity
+        FRAMEWORK="react" yarn run test:e2e:sanity --shard=${{ matrix.shard }}/${{ inputs.shards }}
       workflowName: "E2E Tests on Venv"
       runs_on: ubuntu-latest-4-cores
     secrets: inherit
 
   run-api-test:
-    name: Run API Tests on Venv
+    name: Run API Tests on Venv (Shard ${{ matrix.shard }}/${{ inputs.shards }})
     needs: [ prepare-params ]
     if: |
       always() &&
       !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ${{ range(1, inputs.shards + 1) }}
     uses: frontegg/e2e-system-tests/.github/workflows/execute-test-command.yaml@master
     with:
       server_url: ${{ needs.prepare-params.outputs.apiUrl }}
       portal_url: ${{ needs.prepare-params.outputs.portalUrl }}
-      command: "yarn test:api"
+      command: "yarn test:api --shard=${{ matrix.shard }}/${{ inputs.shards }}"
       workflowName: "API Tests on Venv"
     secrets: inherit
 
@@ -183,7 +196,8 @@ jobs:
     if: |
       always() &&
       (needs.prepare-params.outputs.environmentId) &&
-      contains(needs.*.result, 'success')
+      !contains(needs.run-api-test.result, 'failure') &&
+      !contains(needs.run-e2e-test.result, 'failure')
     uses: frontegg/workflows/.github/workflows/remove-single-venv.yaml@master
     with:
       venvId: ${{ needs.prepare-params.outputs.environmentId }}

--- a/.github/workflows/full-test-suite.yaml
+++ b/.github/workflows/full-test-suite.yaml
@@ -26,7 +26,7 @@ on:
         required: false
         description: Dispatch id to update status (repo/sha)
       shards:
-        type: integer
+        type: number
         required: false
         description: Number of shards to split tests into for parallel execution
         default: 1
@@ -132,7 +132,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: ${{ range(1, inputs.shards + 1) }}
+        shard: ${{ fromJSON(format('[{0}]', join(range(1, inputs.shards + 1), ','))) }}
     uses: frontegg/e2e-system-tests/.github/workflows/execute-test-command.yaml@master
     with:
       server_url: ${{ needs.prepare-params.outputs.apiUrl }}
@@ -152,7 +152,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: ${{ range(1, inputs.shards + 1) }}
+        shard: ${{ fromJSON(format('[{0}]', join(range(1, inputs.shards + 1), ','))) }}
     uses: frontegg/e2e-system-tests/.github/workflows/execute-test-command.yaml@master
     with:
       server_url: ${{ needs.prepare-params.outputs.apiUrl }}


### PR DESCRIPTION
Added support for test sharding to improve CI execution time and resource utilization.

The workflow now automatically splits E2E and API tests into 3 parallel matrix jobs, allowing tests to run concurrently across multiple runners.
Tests are distributed across 3 parallel jobs using --shard=X/3 parameters, significantly reducing overall test execution time while maintaining test coverage.