### PR TITLE
Fix flaky full-test-suite bot token creation

### DIFF
--- a/.github/workflows/full-test-suite.yaml
+++ b/.github/workflows/full-test-suite.yaml
@@ -106,6 +106,7 @@ jobs:
           echo "portalUrl=${{ needs.start-venv.outputs.portalUrl }}" >> $GITHUB_OUTPUT
       - id: create_bot_token
         name: Create bot token
+        if: ${{ inputs.dispatch_id }}
         uses: wow-actions/use-app-token@v2
         with:
           app_id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}


### PR DESCRIPTION
## Summary
- Skip GitHub App bot-token creation in `prepare-params` when `dispatch_id` is empty.
- Prevent normal PR venv runs from failing on an unused, flaky token creation step.

## Test plan
- Parsed `.github/workflows/full-test-suite.yaml` locally with Ruby YAML parser.
- Reviewed the branch diff to confirm only the token step condition changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 12a6ef28a920cd4c2e210388c786b541d9e00e2d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->