### PR TITLE
Fix workflows permissions

### DIFF
--- a/.github/workflows/dashboard-test-suite.yaml
+++ b/.github/workflows/dashboard-test-suite.yaml
@@ -104,12 +104,12 @@ jobs:
           echo "portalUrl=${{ needs.start-venv.outputs.portalUrl }}" >> $GITHUB_OUTPUT
       - id: create_bot_token
         name: Create bot token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
           private-key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
           repositories: e2e-system-tests
-          owner: frontegg
+          owner: ${{ github.repository_owner }}
       - name: "Update trigger status"
         uses: frontegg/workflows/.github/shared-actions/update-status@master
         if: ${{ inputs.dispatch_id }}
@@ -140,10 +140,11 @@ jobs:
     steps:
       - id: create_bot_token
         name: Create bot token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
           private-key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
+          owner: ${{ github.repository_owner }}
       - name: "trigger failure status"
         if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
         uses: frontegg/workflows/.github/shared-actions/update-status@master

--- a/.github/workflows/dashboard-test-suite.yaml
+++ b/.github/workflows/dashboard-test-suite.yaml
@@ -104,15 +104,17 @@ jobs:
           echo "portalUrl=${{ needs.start-venv.outputs.portalUrl }}" >> $GITHUB_OUTPUT
       - id: create_bot_token
         name: Create bot token
-        uses: wow-actions/use-app-token@v2
+        uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
-          private_key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
+          app-id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
+          private-key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
+          repositories: e2e-system-tests
+          owner: frontegg
       - name: "Update trigger status"
         uses: frontegg/workflows/.github/shared-actions/update-status@master
         if: ${{ inputs.dispatch_id }}
         with:
-          token: ${{ env.BOT_TOKEN }}
+          token: ${{ steps.create_bot_token.outputs.token }}
           dispatch_id: ${{ inputs.dispatch_id }}
           description: "Start tests environment ${{ steps.variables.outputs.apiUrl }}"
 
@@ -138,15 +140,15 @@ jobs:
     steps:
       - id: create_bot_token
         name: Create bot token
-        uses: wow-actions/use-app-token@v2
+        uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
-          private_key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
+          app-id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
+          private-key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
       - name: "trigger failure status"
         if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
         uses: frontegg/workflows/.github/shared-actions/update-status@master
         with:
-          token: ${{ env.BOT_TOKEN }}
+          token: ${{ steps.create_bot_token.outputs.token }}
           dispatch_id: ${{ inputs.dispatch_id }}
           state: "failure"
           description: "Failed | Api Tests: ${{ needs.run-api-test.result }} | E2E Tests: ${{ needs.run-e2e-test.result }}"
@@ -154,7 +156,7 @@ jobs:
         if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
         uses: frontegg/workflows/.github/shared-actions/update-status@master
         with:
-          token: ${{ env.BOT_TOKEN }}
+          token: ${{ steps.create_bot_token.outputs.token }}
           dispatch_id: ${{ inputs.dispatch_id }}
           state: "success"
           description: "E2E tests passed"

--- a/.github/workflows/full-test-suite.yaml
+++ b/.github/workflows/full-test-suite.yaml
@@ -107,12 +107,12 @@ jobs:
       - id: create_bot_token
         name: Create bot token
         if: ${{ inputs.dispatch_id }}
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
           private-key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
           repositories: e2e-system-tests
-          owner: frontegg
+          owner: ${{ github.repository_owner }}
       - name: "Update trigger status"
         uses: frontegg/workflows/.github/shared-actions/update-status@master
         if: ${{ inputs.dispatch_id }}
@@ -172,12 +172,12 @@ jobs:
     steps:
       - id: create_bot_token
         name: Create bot token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
           private-key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
           repositories: e2e-system-tests
-          owner: frontegg
+          owner: ${{ github.repository_owner }}
       - name: "trigger failure status"
         if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
         uses: frontegg/workflows/.github/shared-actions/update-status@master

--- a/.github/workflows/full-test-suite.yaml
+++ b/.github/workflows/full-test-suite.yaml
@@ -107,15 +107,17 @@ jobs:
       - id: create_bot_token
         name: Create bot token
         if: ${{ inputs.dispatch_id }}
-        uses: wow-actions/use-app-token@v2
+        uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
-          private_key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
+          app-id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
+          private-key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
+          repositories: e2e-system-tests
+          owner: frontegg
       - name: "Update trigger status"
         uses: frontegg/workflows/.github/shared-actions/update-status@master
         if: ${{ inputs.dispatch_id }}
         with:
-          token: ${{ env.BOT_TOKEN }}
+          token: ${{ steps.create_bot_token.outputs.token }}
           dispatch_id: ${{ inputs.dispatch_id }}
           description: 'Start tests environment ${{ steps.variables.outputs.apiUrl }}'
 
@@ -170,15 +172,17 @@ jobs:
     steps:
       - id: create_bot_token
         name: Create bot token
-        uses: wow-actions/use-app-token@v2
+        uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
-          private_key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
+          app-id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
+          private-key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
+          repositories: e2e-system-tests
+          owner: frontegg
       - name: "trigger failure status"
         if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
         uses: frontegg/workflows/.github/shared-actions/update-status@master
         with:
-          token: ${{ env.BOT_TOKEN }}
+          token: ${{ steps.create_bot_token.outputs.token }}
           dispatch_id: ${{ inputs.dispatch_id }}
           state: "failure"
           description: 'Failed | Api Tests: ${{ needs.run-api-test.result }} | E2E Tests: ${{ needs.run-e2e-test.result }}'
@@ -186,7 +190,7 @@ jobs:
         if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
         uses: frontegg/workflows/.github/shared-actions/update-status@master
         with:
-          token: ${{ env.BOT_TOKEN }}
+          token: ${{ steps.create_bot_token.outputs.token }}
           dispatch_id: ${{ inputs.dispatch_id }}
           state: "success"
           description: 'E2E tests passed'

--- a/.github/workflows/sdk-test-suite.yaml
+++ b/.github/workflows/sdk-test-suite.yaml
@@ -96,12 +96,12 @@ jobs:
           echo "portalUrl=https://portal.stg.frontegg.com" >> $GITHUB_OUTPUT
       - id: create_bot_token
         name: Create bot token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
           private-key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
           repositories: e2e-system-tests
-          owner: frontegg
+          owner: ${{ github.repository_owner }}
       - name: "Update trigger status"
         uses: frontegg/workflows/.github/shared-actions/update-status@master
         if: ${{ inputs.dispatch_id }}
@@ -129,12 +129,12 @@ jobs:
           token: ${{ secrets.GH_REPOSITORY_ADMIN_TOKEN }}
       - id: create_bot_token
         name: Create bot token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
           private-key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
           repositories: e2e-system-tests
-          owner: frontegg
+          owner: ${{ github.repository_owner }}
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -197,12 +197,12 @@ jobs:
           token: ${{ secrets.GH_REPOSITORY_ADMIN_TOKEN }}
       - id: create_bot_token
         name: Create bot token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
           private-key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
           repositories: e2e-system-tests
-          owner: frontegg
+          owner: ${{ github.repository_owner }}
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -265,12 +265,12 @@ jobs:
           token: ${{ secrets.GH_REPOSITORY_ADMIN_TOKEN }}
       - id: create_bot_token
         name: Create bot token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
           private-key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
           repositories: e2e-system-tests
-          owner: frontegg
+          owner: ${{ github.repository_owner }}
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -329,12 +329,12 @@ jobs:
           token: ${{ secrets.GH_REPOSITORY_ADMIN_TOKEN }}
       - id: create_bot_token
         name: Create bot token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
           private-key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
           repositories: e2e-system-tests
-          owner: frontegg
+          owner: ${{ github.repository_owner }}
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -385,12 +385,12 @@ jobs:
     steps:
       - id: create_bot_token
         name: Create bot token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
           private-key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
           repositories: e2e-system-tests
-          owner: frontegg
+          owner: ${{ github.repository_owner }}
       - name: "trigger failure status"
         if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
         uses: frontegg/workflows/.github/shared-actions/update-status@master

--- a/.github/workflows/sdk-test-suite.yaml
+++ b/.github/workflows/sdk-test-suite.yaml
@@ -96,15 +96,17 @@ jobs:
           echo "portalUrl=https://portal.stg.frontegg.com" >> $GITHUB_OUTPUT
       - id: create_bot_token
         name: Create bot token
-        uses: wow-actions/use-app-token@v2
+        uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
-          private_key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
+          app-id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
+          private-key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
+          repositories: e2e-system-tests
+          owner: frontegg
       - name: "Update trigger status"
         uses: frontegg/workflows/.github/shared-actions/update-status@master
         if: ${{ inputs.dispatch_id }}
         with:
-          token: ${{ env.BOT_TOKEN }}
+          token: ${{ steps.create_bot_token.outputs.token }}
           dispatch_id: ${{ inputs.dispatch_id }}
           description: 'Start tests environment ${{ steps.variables.outputs.apiUrl }}'
 
@@ -127,10 +129,12 @@ jobs:
           token: ${{ secrets.GH_REPOSITORY_ADMIN_TOKEN }}
       - id: create_bot_token
         name: Create bot token
-        uses: wow-actions/use-app-token@v2
+        uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
-          private_key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
+          app-id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
+          private-key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
+          repositories: e2e-system-tests
+          owner: frontegg
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -168,7 +172,7 @@ jobs:
           react_version: ${{ inputs.react_version }} # deprecated
           client_framework: ${{ inputs.client_framework }}
           client_framework_version: ${{ inputs.client_framework_version }}
-          bot_token: ${{ env.BOT_TOKEN }}
+          bot_token: ${{ steps.create_bot_token.outputs.token }}
           environment: "staging"
           frontegg_client_id: ${{ secrets.FRONTEGG_STG_CLIENT_ID }}
           frontegg_secret: ${{ secrets.FRONTEGG_STG_SECRET }}
@@ -193,10 +197,12 @@ jobs:
           token: ${{ secrets.GH_REPOSITORY_ADMIN_TOKEN }}
       - id: create_bot_token
         name: Create bot token
-        uses: wow-actions/use-app-token@v2
+        uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
-          private_key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
+          app-id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
+          private-key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
+          repositories: e2e-system-tests
+          owner: frontegg
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -234,7 +240,7 @@ jobs:
           react_version: ${{ inputs.react_version }} # deprecated
           client_framework: ${{ inputs.client_framework }}
           client_framework_version: ${{ inputs.client_framework_version }}
-          bot_token: ${{ env.BOT_TOKEN }}
+          bot_token: ${{ steps.create_bot_token.outputs.token }}
           environment: "staging"
           frontegg_client_id: ${{ secrets.FRONTEGG_STG_CLIENT_ID }}
           frontegg_secret: ${{ secrets.FRONTEGG_STG_SECRET }}
@@ -259,10 +265,12 @@ jobs:
           token: ${{ secrets.GH_REPOSITORY_ADMIN_TOKEN }}
       - id: create_bot_token
         name: Create bot token
-        uses: wow-actions/use-app-token@v2
+        uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
-          private_key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
+          app-id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
+          private-key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
+          repositories: e2e-system-tests
+          owner: frontegg
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -300,7 +308,7 @@ jobs:
           react_version: ${{ inputs.react_version }} # deprecated
           client_framework: ${{ inputs.client_framework }}
           client_framework_version: ${{ inputs.client_framework_version }}
-          bot_token: ${{ env.BOT_TOKEN }}
+          bot_token: ${{ steps.create_bot_token.outputs.token }}
           environment: "staging"
           frontegg_client_id: ${{ secrets.FRONTEGG_STG_CLIENT_ID }}
           frontegg_secret: ${{ secrets.FRONTEGG_STG_SECRET }}
@@ -321,10 +329,12 @@ jobs:
           token: ${{ secrets.GH_REPOSITORY_ADMIN_TOKEN }}
       - id: create_bot_token
         name: Create bot token
-        uses: wow-actions/use-app-token@v2
+        uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
-          private_key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
+          app-id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
+          private-key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
+          repositories: e2e-system-tests
+          owner: frontegg
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -362,7 +372,7 @@ jobs:
           react_version: ${{ inputs.react_version }} # deprecated
           client_framework: ${{ inputs.client_framework }}
           client_framework_version: ${{ inputs.client_framework_version }}
-          bot_token: ${{ env.BOT_TOKEN }}
+          bot_token: ${{ steps.create_bot_token.outputs.token }}
           environment: "staging"
           frontegg_client_id: ${{ secrets.FRONTEGG_STG_CLIENT_ID }}
           frontegg_secret: ${{ secrets.FRONTEGG_STG_SECRET }}
@@ -375,15 +385,17 @@ jobs:
     steps:
       - id: create_bot_token
         name: Create bot token
-        uses: wow-actions/use-app-token@v2
+        uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
-          private_key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
+          app-id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
+          private-key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
+          repositories: e2e-system-tests
+          owner: frontegg
       - name: "trigger failure status"
         if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
         uses: frontegg/workflows/.github/shared-actions/update-status@master
         with:
-          token: ${{ env.BOT_TOKEN }}
+          token: ${{ steps.create_bot_token.outputs.token }}
           dispatch_id: ${{ inputs.dispatch_id }}
           state: "failure"
           description: 'E2E Tests Failed'
@@ -391,7 +403,7 @@ jobs:
         if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
         uses: frontegg/workflows/.github/shared-actions/update-status@master
         with:
-          token: ${{ env.BOT_TOKEN }}
+          token: ${{ steps.create_bot_token.outputs.token }}
           dispatch_id: ${{ inputs.dispatch_id }}
           state: "success"
           description: 'E2E tests passed'

--- a/.github/workflows/test-docker-poc.yaml
+++ b/.github/workflows/test-docker-poc.yaml
@@ -96,12 +96,12 @@ jobs:
           echo "portalUrl=${{ needs.start-venv.outputs.portalUrl }}" >> $GITHUB_OUTPUT
       - id: create_bot_token
         name: Create bot token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
           private-key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
           repositories: e2e-system-tests
-          owner: frontegg
+          owner: ${{ github.repository_owner }}
       - name: "Update trigger status"
         uses: frontegg/workflows/.github/shared-actions/update-status@master
         if: ${{ inputs.dispatch_id }}

--- a/.github/workflows/test-docker-poc.yaml
+++ b/.github/workflows/test-docker-poc.yaml
@@ -96,15 +96,17 @@ jobs:
           echo "portalUrl=${{ needs.start-venv.outputs.portalUrl }}" >> $GITHUB_OUTPUT
       - id: create_bot_token
         name: Create bot token
-        uses: wow-actions/use-app-token@v2
+        uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
-          private_key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
+          app-id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
+          private-key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
+          repositories: e2e-system-tests
+          owner: frontegg
       - name: "Update trigger status"
         uses: frontegg/workflows/.github/shared-actions/update-status@master
         if: ${{ inputs.dispatch_id }}
         with:
-          token: ${{ env.BOT_TOKEN }}
+          token: ${{ steps.create_bot_token.outputs.token }}
           dispatch_id: ${{ inputs.dispatch_id }}
           description: 'Start tests environment ${{ steps.variables.outputs.apiUrl }}'
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how GitHub App tokens are minted in multiple CI workflows; misconfiguration could break status updates and downstream test runs.
> 
> **Overview**
> Updates multiple GitHub Actions test workflows to use `actions/create-github-app-token@v2` instead of `@v1` when generating the bot token.
> 
> Replaces the hardcoded `owner: frontegg` setting with `owner: ${{ github.repository_owner }}` (and adds `owner` where it was missing) to ensure token creation targets the correct org/repo for status updates and test-suite triggers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c792dcb85e988e7d0c9bc4caa4422a8a263ae54c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->