### PR TITLE
fix: remove repo scope restriction and add statuses:write permission

### DIFF
--- a/.github/workflows/dashboard-test-suite.yaml
+++ b/.github/workflows/dashboard-test-suite.yaml
@@ -75,6 +75,7 @@ permissions:
   contents: read
   issues: read
   checks: write
+  statuses: write
   pull-requests: write
   
 jobs:
@@ -108,7 +109,6 @@ jobs:
         with:
           app-id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
           private-key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
-          repositories: e2e-system-tests
           owner: ${{ github.repository_owner }}
       - name: "Update trigger status"
         uses: frontegg/workflows/.github/shared-actions/update-status@master

--- a/.github/workflows/full-test-suite.yaml
+++ b/.github/workflows/full-test-suite.yaml
@@ -77,6 +77,7 @@ permissions:
   contents: read
   issues: read
   checks: write
+  statuses: write
   pull-requests: write
   
 jobs:
@@ -111,7 +112,6 @@ jobs:
         with:
           app-id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
           private-key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
-          repositories: e2e-system-tests
           owner: ${{ github.repository_owner }}
       - name: "Update trigger status"
         uses: frontegg/workflows/.github/shared-actions/update-status@master
@@ -176,7 +176,6 @@ jobs:
         with:
           app-id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
           private-key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
-          repositories: e2e-system-tests
           owner: ${{ github.repository_owner }}
       - name: "trigger failure status"
         if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}

--- a/.github/workflows/sdk-test-suite.yaml
+++ b/.github/workflows/sdk-test-suite.yaml
@@ -78,6 +78,7 @@ permissions:
   contents: read
   issues: read
   checks: write
+  statuses: write
   pull-requests: write
   
 jobs:
@@ -100,7 +101,6 @@ jobs:
         with:
           app-id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
           private-key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
-          repositories: e2e-system-tests
           owner: ${{ github.repository_owner }}
       - name: "Update trigger status"
         uses: frontegg/workflows/.github/shared-actions/update-status@master
@@ -133,7 +133,6 @@ jobs:
         with:
           app-id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
           private-key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
-          repositories: e2e-system-tests
           owner: ${{ github.repository_owner }}
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -201,7 +200,6 @@ jobs:
         with:
           app-id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
           private-key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
-          repositories: e2e-system-tests
           owner: ${{ github.repository_owner }}
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -269,7 +267,6 @@ jobs:
         with:
           app-id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
           private-key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
-          repositories: e2e-system-tests
           owner: ${{ github.repository_owner }}
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -333,7 +330,6 @@ jobs:
         with:
           app-id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
           private-key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
-          repositories: e2e-system-tests
           owner: ${{ github.repository_owner }}
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -389,7 +385,6 @@ jobs:
         with:
           app-id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
           private-key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
-          repositories: e2e-system-tests
           owner: ${{ github.repository_owner }}
       - name: "trigger failure status"
         if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}

--- a/.github/workflows/test-docker-poc.yaml
+++ b/.github/workflows/test-docker-poc.yaml
@@ -67,6 +67,7 @@ permissions:
   contents: read
   issues: read
   checks: write
+  statuses: write
   pull-requests: write
   
 jobs:
@@ -100,7 +101,6 @@ jobs:
         with:
           app-id: ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
           private-key: ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
-          repositories: e2e-system-tests
           owner: ${{ github.repository_owner }}
       - name: "Update trigger status"
         uses: frontegg/workflows/.github/shared-actions/update-status@master


### PR DESCRIPTION
## Summary
- Removed `repositories: e2e-system-tests` from all `create-github-app-token` steps — the token was too narrowly scoped and couldn't write commit statuses on the dispatching repo (e.g. `frontegg-react`), causing `403 Resource not accessible by integration` errors.
- Added `statuses: write` permission to all 4 workflow files, required by the `update-status` shared action to call the `createCommitStatus` API.

Follows up on https://github.com/frontegg/e2e-system-tests/pull/954

## Files changed
- `.github/workflows/sdk-test-suite.yaml`
- `.github/workflows/full-test-suite.yaml`
- `.github/workflows/test-docker-poc.yaml`
- `.github/workflows/dashboard-test-suite.yaml`

## Test plan
- [ ] Trigger an SDK version test (e.g. from `frontegg-react`) and verify the `update-status` step no longer fails with 403

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-permissions change; it only adjusts GitHub token scoping and adds `statuses: write`, which could affect CI status reporting but not product runtime behavior.
> 
> **Overview**
> Fixes commit-status updates for dispatched test runs by granting workflows `statuses: write` and removing the `repositories: e2e-system-tests` restriction from `actions/create-github-app-token` steps.
> 
> This allows the shared `update-status` action to create commit statuses on the dispatching repository (avoiding `403 Resource not accessible by integration` in cross-repo triggers).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4a0bc61c6f62cf1860a49dd50c2c3295be53690. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->