### PR TITLE
FR-25895: Fail fast e2e when PR branch is behind base

### DIFF
--- a/.github/workflows/full-test-suite.yaml
+++ b/.github/workflows/full-test-suite.yaml
@@ -81,8 +81,39 @@ permissions:
   pull-requests: write
   
 jobs:
+  # Fail fast on PRs that are behind the base branch so we don't spin up a
+  # venv / run e2e that will need to be re-run after an update anyway.
+  # Skipped for merge_group / workflow_dispatch / other non-PR callers.
+  check-up-to-date:
+    name: Check PR is up to date with base
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Fail if behind base branch
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git fetch --no-tags origin "$BASE_REF"
+          if ! git merge-base --is-ancestor "origin/$BASE_REF" HEAD; then
+            echo "::error::PR branch is behind '$BASE_REF'. Update the branch, then re-run e2e."
+            git --no-pager log --oneline "HEAD..origin/$BASE_REF" | head -20
+            exit 1
+          fi
+          echo "PR is up to date with origin/$BASE_REF"
+
   start-venv:
     name: Start venv
+    needs: [ check-up-to-date ]
+    if: |
+      always() &&
+      !cancelled() &&
+      (needs.check-up-to-date.result == 'success' || needs.check-up-to-date.result == 'skipped')
     uses: frontegg/workflows/.github/workflows/start-venv.yaml@master
     with:
       volatileEnvironment: true
@@ -121,9 +152,40 @@ jobs:
           dispatch_id: ${{ inputs.dispatch_id }}
           description: 'Start tests environment ${{ steps.variables.outputs.apiUrl }}'
 
+  # Re-check once after venv is ready so we don't start e2e/API if master
+  # moved during venv startup. Running shards are not cancelled mid-flight.
+  recheck-up-to-date:
+    name: Recheck PR is still up to date
+    runs-on: ubuntu-latest
+    needs: [ prepare-params ]
+    if: |
+      always() &&
+      !cancelled() &&
+      github.event_name == 'pull_request' &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled')
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Fail if behind base branch
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git fetch --no-tags origin "$BASE_REF"
+          if ! git merge-base --is-ancestor "origin/$BASE_REF" HEAD; then
+            echo "::error::PR fell behind '$BASE_REF' during the run. Update the branch and re-run."
+            git --no-pager log --oneline "HEAD..origin/$BASE_REF" | head -20
+            exit 1
+          fi
+          echo "PR is still up to date with origin/$BASE_REF"
+
   run-e2e-test:
     name: Run E2E Tests on Venv
-    needs: [ prepare-params ]
+    needs: [ prepare-params, recheck-up-to-date ]
     if: |
       always() &&
       !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
@@ -145,7 +207,7 @@ jobs:
 
   run-api-test:
     name: Run API Tests on Venv
-    needs: [ prepare-params ]
+    needs: [ prepare-params, recheck-up-to-date ]
     if: |
       always() &&
       !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
@@ -167,7 +229,7 @@ jobs:
   update-trigger-status:
     name: Update trigger status
     runs-on: ubuntu-latest
-    needs: [ run-api-test, run-e2e-test, start-venv, prepare-params ]
+    needs: [ check-up-to-date, recheck-up-to-date, run-api-test, run-e2e-test, start-venv, prepare-params ]
     if: ${{ always() && inputs.dispatch_id }}
     steps:
       - id: create_bot_token


### PR DESCRIPTION
## Summary
- Fail fast in the shared `full-test-suite` workflow when a PR branch is behind its base branch, before starting the venv.
- Re-check once after venv is ready (before e2e/API jobs). Running shards are not cancelled mid-flight.
- Non-PR callers (`merge_group`, `workflow_dispatch`, etc.) skip the gate and behave as before.

## Context
Out-of-date PR e2e runs (e.g. auth-hub) are mostly wasted — the branch usually needs an update and e2e re-run. Putting the gate in `frontegg/workflows` covers all service callers.

Jira: [FR-25895](https://frontegg.atlassian.net/browse/FR-25895)

## Test plan
- [ ] On a service PR that calls `full-test-suite` (e.g. auth-hub), open/sync a branch that is behind master → e2e should fail fast at "Check PR is up to date with base" without starting a venv
- [ ] Update that branch with master → gate passes and e2e proceeds normally
- [ ] Confirm merge-queue / workflow_dispatch callers still skip the gate and run as before

Made with [Cursor](https://cursor.com)

[FR-25895]: https://frontegg.atlassian.net/browse/FR-25895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ